### PR TITLE
Provide hostname when setting cert thumbprint

### DIFF
--- a/lib/puppet/provider/winrmssl/ruby_openssl.rb
+++ b/lib/puppet/provider/winrmssl/ruby_openssl.rb
@@ -232,7 +232,7 @@ Puppet::Type.type(:winrmssl).provide(:ruby_openssl) do
   end
 
   def certificatethumbprint=(var_param)
-    var_cmd = "winrm set winrm/config/listener?Address=*+Transport=HTTPS @{CertificateThumbprint=\"#{var_param}\"}"
+    var_cmd = "winrm set winrm/config/listener?Address=*+Transport=HTTPS @{Hostname=\"#{Facter['fqdn'].value}\";CertificateThumbprint=\"#{var_param}\"}"
     _, exitstatus = exec_call(var_cmd)
     exitstatus
   end


### PR DESCRIPTION
This fixes the edge case where a node has been renamed and a new Puppet certificate was created for the node. Switching only the certificatethumbprint will fail as the hostname won't match the Subject Name of the new certificate. By also providing the fqdn fact to the Hostname parameter, switching becomes possible.